### PR TITLE
remove the "phpList Help: $topic" heading

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,7 +55,6 @@ if ($topic) {
 <body>
 <!-- content -->
 <?php
-print "<h3>phplist Help: $topic</h3>";
 if ($include) {
     include $include;
 } else {


### PR DESCRIPTION
I think the heading element should be removed from the help text files for the aesthetic reasons because sometimes the "$topic" which is the file name is not always consistent and I suggest adding the "heading" manually in the text files.
**Before:**
![screenshot from 2018-04-18 13-56-25](https://user-images.githubusercontent.com/9008509/38930629-d9ef8cee-4310-11e8-95df-b455f8b37af8.png)
**After:**
![screenshot from 2018-04-18 13-59-10](https://user-images.githubusercontent.com/9008509/38930620-d3b07118-4310-11e8-80b2-16cb4fd0df69.png)

