### PR TITLE
Update help for 'n' specifier to format month without leading 0.

### DIFF
--- a/en/date_format.php
+++ b/en/date_format.php
@@ -4,6 +4,7 @@ d   2-digit day with leading zero
 j   day without leading zero
 F   long representation of month
 m   2-digit month with leading zero
+n   month without leading zero
 M   short representation of month
 y   2-digit year
 Y   4-digit year
@@ -14,5 +15,6 @@ Examples of the format string and the formatted date<br>
 j F Y   6 April 2020
 M j, y  Apr 6, 20
 Y-m-d   2020-04-06
+j/n/y   6/4/20
 </pre>
 <p>On some pages, such as Statistics Overview, the month name will be displayed in short representation regardless of this setting.</p>


### PR DESCRIPTION
Add help text and an example.